### PR TITLE
Additional unit support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,8 @@ npm install timeparse
 
 ```js
 var timeparse = require('timeparse');
-var result = timeparse('2m2s'); // 122000 (2 minutes and 2 seconds in miliseconds)
+var result = timeparse('2m2s'); // 122000 (2 minutes and 2 seconds in milliseconds)
+var result2 = timeparse('3m43s', 's') //223 (3 minutes, 43 seconds in seconds)
 ```
 
 ## Units
@@ -24,6 +25,8 @@ var result = timeparse('2m2s'); // 122000 (2 minutes and 2 seconds in milisecond
 - **h**: hours
 - **m**: minutes
 - **s**: seconds
+- **ms**: milliseconds
+- **μs**: microseconds
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,17 +1,21 @@
 'use strict';
 
 var units = {
-  s: 1,
-  m: 60,
-  h: 60 * 60,
-  d: 60 * 60 * 24,
-  w: 60 * 60 * 24 * 7
+  μs : 1,
+  ms : 1000,
+  s  : 1000 * 1000,
+  m  : 1000 * 1000 * 60,
+  h  : 1000 * 1000 * 60 * 60,
+  d  : 1000 * 1000 * 60 * 60 * 24,
+  w  : 1000 * 1000 * 60 * 60 * 24 * 7
 };
 
 module.exports = parse;
 
 function parse(string, returnUnit) {
-  var totalSeconds = 0;
+  returnUnit = returnUnit || 'ms';
+
+  var totalMicroseconds = 0;
 
   var groups = string
     .toLowerCase()
@@ -23,14 +27,14 @@ function parse(string, returnUnit) {
       var value = g.match(/[0-9]+/g)[0];
       var unit = g.match(/[a-z]+/g)[0];
 
-      totalSeconds += getSeconds(value, unit);
+      totalMicroseconds += getMicroseconds(value, unit);
     });
   }
 
-  return totalSeconds * 1000;
+  return totalMicroseconds / units[returnUnit];
 }
 
-function getSeconds(value, unit) {
+function getMicroseconds(value, unit) {
   var result = units[unit];
 
   if (result) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timeparse",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Time parse utility",
   "main": "index.js",
   "scripts": {

--- a/test/stuff.js
+++ b/test/stuff.js
@@ -13,4 +13,14 @@ describe('timeparse', function() {
     assert.equal(tp('1w'), 604800000);
     assert.equal(tp('2m2s'), 122000);
   });
+
+  it('should respect return unit specification', function() {
+    assert.equal(tp('1s', 'ms'), 1000);
+    assert.equal(tp('1m', 's'), 60);
+    assert.equal(tp('5m', 'μs'), 300000000);
+    assert.equal(tp('1h', 'm'), 60);
+    assert.equal(tp('1d', 'h'), 24);
+    assert.equal(tp('1w', 'ms'), 604800000);
+    assert.equal(tp('2m2s', 's'), 122);
+  });
 });


### PR DESCRIPTION
Added support for micro(μs) and milliseconds(ms).

Behavior is still the same (defaults to returning millisecond
representation). Can also now pass in the unit you want returned.
