### PR TITLE
Support decimal numbers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,7 @@ npm install timeparse
 var timeparse = require('timeparse');
 var result = timeparse('2m2s'); // 122000 (2 minutes and 2 seconds in milliseconds)
 var result2 = timeparse('3m43s', 's') //223 (3 minutes, 43 seconds in seconds)
+var result3 = timeparse('46.30ms', 'μs') //46300
 ```
 
 ## Units

--- a/index.js
+++ b/index.js
@@ -19,12 +19,12 @@ function parse(string, returnUnit) {
 
   var groups = string
     .toLowerCase()
-    .replace(/[^\.\w+-]+/g, '')
-    .match(/[-+]?[0-9]+[a-z]+/g);
+    .match(/[-+]?[0-9\.]+[a-z]+/g);
+
 
   if (groups !== null) {
     groups.forEach(function (g) {
-      var value = g.match(/[0-9]+/g)[0];
+      var value = g.match(/[0-9\.]+/g)[0];
       var unit = g.match(/[a-z]+/g)[0];
 
       totalMicroseconds += getMicroseconds(value, unit);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timeparse",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Time parse utility",
   "main": "index.js",
   "scripts": {

--- a/test/stuff.js
+++ b/test/stuff.js
@@ -23,4 +23,8 @@ describe('timeparse', function() {
     assert.equal(tp('1w', 'ms'), 604800000);
     assert.equal(tp('2m2s', 's'), 122);
   });
+
+  it('should handle decimals', function() {
+    assert.equal(tp('46.300ms', 'μs'), 46300);
+  });
 });


### PR DESCRIPTION
I bumped it to version 1.0.0 since this could potentially be
surprising behavior. I know floating point math can be a bit
of a hazard in JavaScript. We could always consider using
something like bigint/bignum.

[bigint](https://npmjs.com/package/bigint)
[bignum](https://npmjs.com/package/bignum)

Depends on #1 
